### PR TITLE
fix: target net8.0-windows in Testing project to fix release build

### DIFF
--- a/Testing/Testing.csproj
+++ b/Testing/Testing.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 


### PR DESCRIPTION
The release build failed at the 'Build the Installer' step (which builds the whole solution) with:

  Testing.csproj : error NU1201: Project DTC is not compatible with
  net7.0-windows7.0. Project DTC supports: net8.0-windows7.0

Testing referenced DTC (net8.0-windows) while still targeting net7.0-windows, which is both incompatible and out of support (NETSDK1138). Align Testing to net8.0-windows so the full solution restores and the installer builds.