### PR TITLE
fix: target net8.0-windows in FolderProfile publish profile

### DIFF
--- a/dcs-dtc/Properties/PublishProfiles/FolderProfile.pubxml
+++ b/dcs-dtc/Properties/PublishProfiles/FolderProfile.pubxml
@@ -9,7 +9,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>D:\DTC v476th 2026-02-24</PublishDir>
     <PublishProtocol>FileSystem</PublishProtocol>
     <_TargetId>Folder</_TargetId>
-    <TargetFramework>net7.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <SelfContained>false</SelfContained>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <PublishReadyToRun>true</PublishReadyToRun>


### PR DESCRIPTION
The release installer build failed at 'Build the Installer' with:
  ERROR: Invalid or unspecified target for shortcut 'DTC for DCS'

The installer's primary output is the key output of the PublishItems group, which DevEnv produces by publishing DTC through FolderProfile.pubxml. That profile still targeted net7.0-windows while the project was migrated to net8.0-windows, so the publish yielded no valid key output and the shortcut target became unresolvable. Align the profile to net8.0-windows (same leftover-net7 issue previously fixed in Testing.csproj).